### PR TITLE
Add Multisite SSL config templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains the Nginx configurations used within the series [Hostin
 * ssl-fastcgi-cache.com - WordPress on HTTPS with FastCGI caching
 * multisite-subdomain.com - WordPress Multisite install using subdomains
 * multisite-subdirectory.com - WordPress Multisite install using subdirectories
+* ssl-multisite-subdomain.com - WordPress Multisite install using subdomains on HTTPS
+* ssl-multisite-subdirectory.com - WordPress Multisite install using subdirectories on HTTPS
 
 Looking for a modern hosting environment provisioned using Ansible? Check out [WordPress Ansible](https://github.com/A5hleyRich/wordpress-ansible).
 

--- a/sites-available/.gitignore
+++ b/sites-available/.gitignore
@@ -10,3 +10,5 @@
 !singlesite.com
 !ssl.com
 !ssl-fastcgi-cache.com
+!ssl-multisite-subdirectory.com
+!ssl-multisite-subdomain.com

--- a/sites-available/ssl-multisite-subdirectory.com
+++ b/sites-available/ssl-multisite-subdirectory.com
@@ -1,0 +1,69 @@
+server {
+    # Ports to listen on
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    # Server name to listen for
+    server_name ssl-multisite-subdirectory.com;
+
+    # Path to document root
+    root /sites/ssl-multisite-subdirectory.com/public;
+
+    # Paths to certificate files.
+    ssl_certificate /etc/letsencrypt/live/ssl-multisite-subdirectory.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ssl-multisite-subdirectory.com/privkey.pem;
+
+    # File to be used as index
+    index index.php;
+    
+    #send logs to global aggregate logs
+    error_log /var/log/nginx/error.log warn;
+    access_log /var/log/nginx/access.log;
+
+    # Site specific logs.
+    access_log /sites/ssl-multisite-subdirectory.com/logs/access.log;
+    error_log /sites/ssl-multisite-subdirectory.com/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # Multisite subdirectory install
+    include global/server/multisite-subdirectory.conf;
+
+    # SSL rules
+    include global/server/ssl.conf;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include global/fastcgi-params.conf;
+
+        # Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
+    }
+
+    # Rewrite robots.txt
+    rewrite ^/robots.txt$ /index.php last;
+}
+
+# Redirect http to https
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ssl-multisite-subdirectory.com www.ssl-multisite-subdirectory.com;
+
+    return 301 https://ssl-multisite-subdirectory.com$request_uri;
+}
+
+# Redirect www to non-www
+server {
+    listen 443;
+    listen [::]:443;
+    server_name www.ssl-multisite-subdirectory.com;
+
+    return 301 https://ssl-multisite-subdirectory.com$request_uri;
+}

--- a/sites-available/ssl-multisite-subdomain.com
+++ b/sites-available/ssl-multisite-subdomain.com
@@ -1,0 +1,66 @@
+server {
+    # Ports to listen on
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    # Server name to listen for
+    server_name ssl-multisite-subdomain.com *.ssl-multisite-subdomain.com;
+
+    # Path to document root
+    root /sites/ssl-multisite-subdomain.com/public;
+
+    # Paths to certificate files.
+    ssl_certificate /etc/letsencrypt/live/ssl-multisite-subdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ssl-multisite-subdomain.com/privkey.pem;
+
+    # File to be used as index
+    index index.php;
+    
+    #send logs to global aggregate logs
+    error_log /var/log/nginx/error.log warn;
+    access_log /var/log/nginx/access.log;
+
+    # Site specific logs.
+    access_log /sites/ssl-multisite-subdomain.com/logs/access.log;
+    error_log /sites/ssl-multisite-subdomain.com/logs/error.log;
+
+    # Default server block rules
+    include global/server/defaults.conf;
+
+    # SSL rules
+    include global/server/ssl.conf;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        include global/fastcgi-params.conf;
+
+        # Use the php pool defined in the upstream variable.
+        # See global/php-pool.conf for definition.
+        fastcgi_pass   $upstream;
+    }
+
+    # Rewrite robots.txt
+    rewrite ^/robots.txt$ /index.php last;
+}
+
+# Redirect http to https
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ssl-multisite-subdomain.com www.ssl-multisite-subdomain.com;
+
+    return 301 https://ssl-multisite-subdomain.com$request_uri;
+}
+
+# Redirect www to non-www
+server {
+    listen 443;
+    listen [::]:443;
+    server_name www.ssl-multisite-subdomain.com;
+
+    return 301 https://ssl-multisite-subdomain.com$request_uri;
+}


### PR DESCRIPTION
## Functionality this Pull Request adds
- ability to setup WP as MultiSite on SSL (two new config templates were added).

### How has this been tested
- This was tested locally by running an Ansible Playbook that used this NGINX repository (and work branch) to setup a new web server and WP sites.